### PR TITLE
check if chat_obj contains username

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -224,7 +224,7 @@ def setup_notifications():
         for message_obj in resp.json()['result']:
             chat_obj = message_obj['message']['chat']
 
-            if chat_obj['username'] == user_input:
+            if 'username' in chat_obj.keys() and chat_obj['username'] == user_input:
                 backup_options['telegram_user_id'] = chat_obj['id']
                 send_notif(chat_obj['id'],
                     "Hi {0},\n\nStarting today you'll receive updates about "


### PR DESCRIPTION
While setting up notifications via the Telegram bot, I sent it an initial message when my Telegram profile did not have a `username` set.

As a result, the response of recent events of the Telegram bot contained a message that did not have a `username` field:
![image](https://user-images.githubusercontent.com/8961232/87250819-2b0a2100-c485-11ea-8d49-0ee422f50bcf.png)

And the setup script was crashing:
![image](https://user-images.githubusercontent.com/8961232/87250830-3bba9700-c485-11ea-9c3d-8b5b531c2441.png)

This fix checks if the `chat` dict contains a `username` key to avoid this problem.